### PR TITLE
add excluding filter

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/Messages.properties
@@ -44,6 +44,7 @@ GitHubSCMSource.NoMatchingOwner=Could not find owner: {0}
 GitHubSCMSource.CouldNotConnectionGithub=Could not connect github with credential: {0}
 
 OriginPullRequestDiscoveryTrait.authorityDisplayName=Trust origin pull requests
+OriginPullRequestDiscoveryTrait.ExcludeModdedJenkins=Merge and Exclude Jenkinsfile modifications
 PullRequestSCMHead.Pronoun=Pull Request
 BranchDiscoveryTrait.excludePRs=Exclude branches that are also filed as PRs
 BranchDiscoveryTrait.onlyPRs=Only branches that are also filed as PRs

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/OriginPullRequestDiscoveryTrait/help-strategyId.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/OriginPullRequestDiscoveryTrait/help-strategyId.html
@@ -16,7 +16,8 @@
         </dd>
         <dt>Merging the pull request, Exclude Jenkinsfile modifications</dt>
         <dd>Discover each pull request once with the discovered revision corresponding to the result of merging with the
-            current revision of the target branch, Excludes Jenkinsfile modifications
+            current revision of the target branch, Excludes Jenkinsfile modifications except those created by
+            whitelisted users/teams.
         </dd>
     </dl>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/OriginPullRequestDiscoveryTrait/help-strategyId.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/OriginPullRequestDiscoveryTrait/help-strategyId.html
@@ -14,5 +14,9 @@
             the current revision of the target branch in each scan. The second parallel discovered revision corresponds
             to the pull request head revision without merging
         </dd>
+        <dt>Merging the pull request, Exclude Jenkinsfile modifications</dt>
+        <dd>Discover each pull request once with the discovered revision corresponding to the result of merging with the
+            current revision of the target branch, Excludes Jenkinsfile modifications
+        </dd>
     </dl>
 </div>


### PR DESCRIPTION
This change adds a filter to the OriginPullRequestDiscoveryTrait that excludes heads that have modified Jenkinsfile

To test:
Requirements: JDK 8 and Maven 3.5.2
checkout branch
```
mvn hpi:run
```
This will create a local Jenkins instance at `http://localhost:8080/jenkins`